### PR TITLE
Remove unnecessary sign from Telegram link text

### DIFF
--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -81,7 +81,7 @@ export default function Contribute() {
                   {t('French-speaking telegram group', {ns: 'contribute'})}
                 </li>
                 <li>
-                  <a href="https://t.me/Idena_RU">'Telegram</a>{' '}
+                  <a href="https://t.me/Idena_RU">Telegram</a>{' '}
                   {t('Russian-speaking group', {ns: 'contribute'})}
                 </li>
                 <li>


### PR DESCRIPTION
<img width="807" alt="Screenshot 2021-07-14 at 10 00 22" src="https://user-images.githubusercontent.com/84582633/125585985-20b7ef7f-bf46-40ed-a4c2-3be5efe49784.png">
