### PR TITLE
Update i18n.js

### DIFF
--- a/shared/utils/i18n.js
+++ b/shared/utils/i18n.js
@@ -312,7 +312,7 @@ export const isoLangs = {
   },
   ja: {
     name: 'Japanese',
-    nativeName: '日本語 (にほんご／にっぽんご)',
+    nativeName: '日本語',
   },
   jv: {
     name: 'Javanese',


### PR DESCRIPTION
Having those hiragana seems odd for native Japanese people, and also out of current practical global standard language selection listing. Thus, strongly recommend to remove them, while desirable somewhere else to express extensive interest in the region.