### PR TITLE
Fix weird "native name" of French

### DIFF
--- a/shared/utils/i18n.js
+++ b/shared/utils/i18n.js
@@ -212,7 +212,7 @@ export const isoLangs = {
   },
   fr: {
     name: 'French',
-    nativeName: 'français, langue française',
+    nativeName: 'Français',
   },
   ff: {
     name: 'Fula; Fulah; Pulaar; Pular',


### PR DESCRIPTION
It was "français, langue française" before, which would have transliterated to "french, french (female) language"